### PR TITLE
resolves #11 use camelcase style for option names

### DIFF
--- a/src/main/groovy/com/craigburke/asciidoctor/AsciiDoctorProcessor.groovy
+++ b/src/main/groovy/com/craigburke/asciidoctor/AsciiDoctorProcessor.groovy
@@ -8,6 +8,7 @@ import asset.pipeline.AbstractProcessor
 import asset.pipeline.AssetCompiler
 import asset.pipeline.AssetFile
 import org.asciidoctor.Asciidoctor
+import org.asciidoctor.SafeMode
 
 class AsciiDoctorProcessor extends AbstractProcessor {
 
@@ -36,8 +37,29 @@ class AsciiDoctorProcessor extends AbstractProcessor {
     }
 
     static Map<String, Object> getConvertOptions() {
-        Map options = [header_footer : true ] + config
+        Map options = config.collectEntries { key, val ->
+            [(key.replaceAll(/[A-Z]/) { '_' + it[0].toLowerCase() }): val]
+        }
+        if (options.containsKey('embeddable')) {
+            options.header_footer = !options.remove('embeddable')
+        }
+        else if (!options.containsKey('header_footer')) {
+            options.header_footer = true
+        }
+        options.safe = resolveSafeModeLevel(options.safe)
         options.asImmutable()
     }
 
+    static int resolveSafeModeLevel(Object safe) {
+        if (safe == null) 0
+        else if (safe instanceof Integer) safe
+        else {
+            try {
+                Enum.valueOf(SafeMode, safe.toString().toUpperCase()).level
+            }
+            catch (IllegalArgumentException e) {
+                0
+            }
+        }
+    }
 }

--- a/src/test/groovy/com/craigburke/asciidoctor/AsciiDoctorProcessorSpec.groovy
+++ b/src/test/groovy/com/craigburke/asciidoctor/AsciiDoctorProcessorSpec.groovy
@@ -23,35 +23,58 @@ class AsciiDoctorProcessorSpec extends Specification {
         asciidoctorConfig = [:]
     }
 
-    def "Document doesn't render h1 element when header_footer is false"() {
+    def "Document doesn't render body element when embeddable is true"() {
         setup:
-        asciidoctorConfig = [header_footer: false]
+        asciidoctorConfig = [embeddable: true]
 
         when:
         String result = convertToHtml(input)
-        Document document = Jsoup.parseBodyFragment(result)
 
         then:
-        !document.select('h1')
+        result.startsWith('<div class="paragraph">')
 
         where:
-        input = '= Heading'
+        input = '''\
+        = Heading
+        
+        Lorem ipsum.'''.stripIndent()
     }
 
 
-    def "Document renders h1 element when header_footer is enabled"() {
+    def "Document renders body element when embeddable is false"() {
+        when:
+        String result = convertToHtml(input)
+        Document document = Jsoup.parseBodyFragment(result)
+
+        then:
+        result.startsWith('<!DOCTYPE html>')
+        document.select('#header')
+        document.select('#content')
+        document.select('#footer')
+        document.select('h1').text() == 'Heading'
+
+        where:
+        input = '''\
+        = Heading
+        :!stylesheet:
+
+        Lorem ipsum.'''.stripIndent()
+    }
+
+
+    def "Sets safe mode specified by name"() {
         setup:
-        asciidoctorConfig = [header_footer: true]
+        asciidoctorConfig = [safe: 'server']
 
         when:
         String result = convertToHtml(input)
         Document document = Jsoup.parseBodyFragment(result)
 
         then:
-        document.select('h1').text() == 'Heading'
+        document.select('p').text() == 'server'
 
         where:
-        input = '= Heading'
+        input = '{safe-mode-name}'
     }
 
 
@@ -137,13 +160,12 @@ class AsciiDoctorProcessorSpec extends Specification {
         item2_1Sublist.child(0).text() == "Item 2.1.1"
 
         where:
-        input = """
+        input = '''\
         * Item 1
         ** Item 1.1
         * Item 2
         ** Item 2.1
-        *** Item 2.1.1
-        """
+        *** Item 2.1.1'''.stripIndent()
     }
 
     def "Renders ordered lists correctly"() {
@@ -182,13 +204,12 @@ class AsciiDoctorProcessorSpec extends Specification {
         item2_1Sublist.child(0).text() == "Item 2.1.1"
 
         where:
-        input = """
+        input = '''\
         . Item 1
         .. Item 1.1
         . Item 2
         .. Item 2.1
-        ... Item 2.1.1
-        """
+        ... Item 2.1.1'''.stripIndent()
      }
 
     def "Renders tables correctly"() {
@@ -214,16 +235,12 @@ class AsciiDoctorProcessorSpec extends Specification {
         row3.child(1).text() == 'COL2-3'
 
         where:
-        input = """|===
-
-            | COL1-1 | COL2-1
-
-            | COL1-2 | COL2-2
-
-            | COL1-3 | COL2-3
-
-            |===
-        """
+        input = '''\
+        |===
+        | COL1-1 | COL2-1
+        | COL1-2 | COL2-2
+        | COL1-3 | COL2-3
+        |==='''.stripIndent()
     }
 
     private String convertToHtml(String input) {


### PR DESCRIPTION
- use camelcase style for configuration option names
- convert options to snake case before passing to AsciidoctorJ
- resolve safe model level from string
- introduce embeddable option as alternative way to disable header/footer
- fix tests for embeddable mode
- strip leading whitespace from input text in tests
- set safe mode to unsafe by default
